### PR TITLE
Updated Nix definitions to test with GHC 9.2.5

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -26,8 +26,14 @@ jobs:
           name: theta-idl
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
-      - name: Build Theta
-        run: nix build .#theta -L
+      - name: Build Theta (GHC 8.10.7)
+        run: nix build .#theta_8107 -L
+
+      - name: Build Theta (GHC 9.0.2)
+        run: nix build .#theta_902 -L
+
+      - name: Build Theta (GHC 9.2.5)
+        run: nix build .#theta_925 -L
 
       - name: Cross-Language Tests
         run: nix build .#test -L

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,29 @@
 {
   "nodes": {
+    "all-cabal-hashes-unpacked": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1669930061,
+        "narHash": "sha256-uesjQE/L5nJU8rZiI61Ukv1K3Z4qWXjMoyGpZhKdhoo=",
+        "owner": "commercialhaskell",
+        "repo": "all-cabal-hashes",
+        "rev": "5398472dd4bce77ea344e9dcf47336ebec68fd87",
+        "type": "github"
+      },
+      "original": {
+        "owner": "commercialhaskell",
+        "ref": "current-hackage",
+        "repo": "all-cabal-hashes",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {
@@ -20,11 +37,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1639947939,
-        "narHash": "sha256-pGsM8haJadVP80GFq4xhnSpNitYNQpaXk4cnA796Cso=",
+        "lastModified": 1662220400,
+        "narHash": "sha256-9o2OGQqu4xyLZP9K6kNe1pTHnyPz0Wr3raGYnr9AIgY=",
         "owner": "nix-community",
         "repo": "naersk",
-        "rev": "2fc8ce9d3c025d59fee349c1f80be9785049d653",
+        "rev": "6944160c19cb591eb85bbf9b2f2768a935623ed3",
         "type": "github"
       },
       "original": {
@@ -35,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1647887150,
-        "narHash": "sha256-1TnRvE3qhhafrQnGapaaSVue6nEwRUICkz227TfHHQw=",
+        "lastModified": 1669900182,
+        "narHash": "sha256-EKxjHxRJnP1w+2nnm8pq4Uqkqa5McnfPXcO8cG8Mxzc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4c3c80df545ec5cb26b5480979c3e3f93518cbe5",
+        "rev": "bcb6dbbe30ce7631e5a0865dff1ab9b63d92977d",
         "type": "github"
       },
       "original": {
@@ -49,11 +66,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1648136313,
-        "narHash": "sha256-y/an2ms+XiGctRz9EuiiRLdaPKanhpc0UApILIp/Ho0=",
+        "lastModified": 1669927173,
+        "narHash": "sha256-Z7rSKzC5OuWv5Q7RRNQPZb0jVJRJk0BJB6/fGZzaAIU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6ea8d5ee71793e236a19af3b5686a1ccdb0af3da",
+        "rev": "9063accddd2e68dcc71032459a58399e977374c9",
         "type": "github"
       },
       "original": {
@@ -64,6 +81,7 @@
     },
     "root": {
       "inputs": {
+        "all-cabal-hashes-unpacked": "all-cabal-hashes-unpacked",
         "flake-utils": "flake-utils",
         "naersk-flake": "naersk-flake",
         "nixpkgs": "nixpkgs_2",
@@ -72,11 +90,11 @@
     },
     "rust-overlay": {
       "locked": {
-        "lastModified": 1645464064,
-        "narHash": "sha256-YeN4bpPvHkVOpQzb8APTAfE7/R+MFMwJUMkqmfvytSk=",
+        "lastModified": 1664789696,
+        "narHash": "sha256-UGWJHQShiwLCr4/DysMVFrYdYYHcOqAOVsWNUu+l6YU=",
         "owner": "mozilla",
         "repo": "nixpkgs-mozilla",
-        "rev": "15b7a05f20aab51c4ffbefddb1b448e862dccb7d",
+        "rev": "80627b282705101e7b38e19ca6e8df105031b072",
         "type": "github"
       },
       "original": {

--- a/test/cross-language/default.nix
+++ b/test/cross-language/default.nix
@@ -22,12 +22,14 @@ let
   python-executable = import ./python { inherit pkgs lib; };
 
   build-tools =
-    [ haskell.stylish-haskell
-      haskell.cabal-install
-      haskell.haskell-language-server
-      haskell.hlint
+    [ pkgs.haskellPackages.stylish-haskell
+      pkgs.haskellPackages.cabal-install
+      pkgs.haskellPackages.hlint
+
       pkgs.stack
       pkgs.time-ghc-modules
+
+      haskell.haskell-language-server
 
       rust-executable
       python-executable

--- a/theta/default.nix
+++ b/theta/default.nix
@@ -9,13 +9,16 @@
 , source-overrides
 
 , build-tools ? [               # extra tools available for nix develop
-  # hack to work around stylish-haskell not building with
-  # compiler = "ghc902"
   pkgs.haskellPackages.stylish-haskell
 
   compiler.cabal-install
-  compiler.haskell-language-server
   compiler.hlint
+
+  # TODO: disable tests for ListLike for haskell-language-server
+  #
+  # depends on ListLike, which was taking forever to compile due to
+  # test suite
+  # compiler.haskell-language-server
 
   # for ci/stack-test
   pkgs.stack


### PR DESCRIPTION
Added a version of Theta using GHC 9.2.5 to the Nix flake, updating some pinned Haskell dependency versions